### PR TITLE
Update: add vimdiff format in refactor default

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
         },
         "chatgpt.promptPrefix.refactor": {
           "type": "string",
-          "default": "Refactor this code and explain what's changed: ",
+          "default": "Refactor this code, then show what's changed in vimdiff format and explain what's changed: ",
           "description": "The prompt prefix used for refactoring the selected code",
           "order": 4
         },


### PR DESCRIPTION
ChatGPT sometimes does some small refactoring and it is not easy to know where it is. After adding this prompt, it will show the changes in vimdiff format and explain those changes.