### PR TITLE
Add option to include language id in codeblocks for better context understanding

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,6 +213,12 @@
           "default": true,
           "description": "Append selected code as a codeblock (```...code...```) instead of plain text",
           "order": 10
+        },
+        "chatgpt.codeblockWithLanguageId": {
+          "type": "boolean",
+          "default": true,
+          "description": "Append language id of the selected code to the codeblock (```language...code...```)",
+          "order": 11
         }
       }
     }


### PR DESCRIPTION
### Description:

This update adds a new configuration option called `chatgpt.codeblockWithLanguageId`, which, when enabled, includes the language identifier within the codeblock for the selected text, like this:

````markdown
```javascript
function helloWorld() {
  console.log('Hello world!');
}
```
````

By default, this option is set to `true`.

### Reasoning:

Specifying the language identifier within the codeblock can aid ChatGPT in comprehending the context and generating more accurate responses, thereby improving the overall user experience. By providing users with the option to enable or disable this feature, we offer greater flexibility and control over the behavior of the extension.