### PR TITLE
Add GPT-4o option for Chatgpt: Model dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatgpt",
   "displayName": "ChatGPT: write and improve code using AI",
-  "description": "Use ChatGPT and GPT4 right inside the IDE to enhance and automate your coding with AI-powered assistance (unofficial)",
+  "description": "Use ChatGPT and GPT4o right inside the IDE to enhance and automate your coding with AI-powered assistance (unofficial)",
   "version": "1.1.2",
   "publisher": "timkmecl",
   "icon": "resources/extensionIcon.png",
@@ -20,6 +20,7 @@
     "openai",
     "gpt3",
     "gpt4",
+    "gpt4o",
     "copilot",
     "ai",
     "explain",
@@ -171,7 +172,8 @@
           "type": "string",
           "enum": [
             "gpt-3.5-turbo",
-            "gpt-4"
+            "gpt-4",
+            "gpt-4o"
           ],
           "default": "gpt-3.5-turbo",
           "description": "Which GPT model to use",


### PR DESCRIPTION
Minor edit: adding ChatGPT-4o to the dropdown options for the plugin. It's 50% cheaper than GPT4 and is recommended by the Open AI team (context: https://twitter.com/romainhuet/status/1791532661154156591)

Based on the request by @kuyin here: https://github.com/timkmecl/chatgpt-vscode/issues/46

<img width="516" alt="SCR-20240520-jnbo" src="https://github.com/timkmecl/chatgpt-vscode/assets/493890/a7d948d6-7835-4a18-bda4-233f17ac12ff">
